### PR TITLE
fix(auth): persist updated refresh_token and refresh_expires_at on token refresh

### DIFF
--- a/lkr/auth_service.py
+++ b/lkr/auth_service.py
@@ -377,9 +377,9 @@ class CurrentAuth(BaseModel):
         if self.from_db and new_token:
             if new_token.refresh_token:
                 self.refresh_token = new_token.refresh_token
+                self.refresh_expires_at = refresh_expires_at
             self.access_token = new_token.access_token or self.access_token
             self.token_type = new_token.token_type or self.token_type
-            self.refresh_expires_at = refresh_expires_at
             connection.execute(
                 "UPDATE auth SET access_token = ?, refresh_token = ?, refresh_expires_at = ?, token_type = ?, expires_at = ? WHERE instance_name = ?",
                 (

--- a/lkr/auth_service.py
+++ b/lkr/auth_service.py
@@ -375,11 +375,18 @@ class CurrentAuth(BaseModel):
             datetime.fromisoformat(expires_at) + timedelta(days=30)
         ).isoformat()
         if self.from_db and new_token:
+            if new_token.refresh_token:
+                self.refresh_token = new_token.refresh_token
+            self.access_token = new_token.access_token or self.access_token
+            self.token_type = new_token.token_type or self.token_type
+            self.refresh_expires_at = refresh_expires_at
             connection.execute(
-                "UPDATE auth SET access_token = ?, token_type = ?, expires_at = ? WHERE instance_name = ?",
+                "UPDATE auth SET access_token = ?, refresh_token = ?, refresh_expires_at = ?, token_type = ?, expires_at = ? WHERE instance_name = ?",
                 (
-                    new_token.access_token,
-                    new_token.token_type,
+                    self.access_token,
+                    self.refresh_token,
+                    self.refresh_expires_at,
+                    self.token_type,
                     expires_at,
                     self.instance_name,
                 ),

--- a/tests/test_oauth_account.py
+++ b/tests/test_oauth_account.py
@@ -96,7 +96,10 @@ def test_set_token_refreshes_lookedup_account(temp_db):
 
     # Refresh the token
     new_token = AccessToken(
-        access_token="token-refreshed", token_type="Bearer", expires_in=3600
+        access_token="token-refreshed",
+        refresh_token="refresh-target-new",
+        token_type="Bearer",
+        expires_in=3600,
     )
     curr.set_token(auth_service.conn, new_token=new_token, commit=True)
 
@@ -104,9 +107,10 @@ def test_set_token_refreshes_lookedup_account(temp_db):
     conn = sqlite3.connect(temp_db)
     conn.row_factory = sqlite3.Row
     row = conn.execute(
-        "SELECT access_token, current_instance FROM auth WHERE instance_name = 'target-inst'"
+        "SELECT access_token, refresh_token, current_instance FROM auth WHERE instance_name = 'target-inst'"
     ).fetchone()
     assert row["access_token"] == "token-refreshed"
+    assert row["refresh_token"] == "refresh-target-new"
     assert row["current_instance"] == 0  # Still not active!
 
     # Verify that active-inst was NOT touched


### PR DESCRIPTION
## Summary
Fixes an issue where renewing or refreshing tokens did not update or save `refresh_token` and `refresh_expires_at` in the database.

## Changes
- In `CurrentAuth.set_token()` ([lkr/auth_service.py](file:///usr/local/google/home/bryanweber/lkrdev/cli/lkr/auth_service.py)), updated the SQL `UPDATE auth` statement to persist `refresh_token` and `refresh_expires_at` alongside `access_token` and `token_type`.
- Updated in-memory properties on `CurrentAuth` when a new `refresh_token` is present.
- Added tests in `tests/test_oauth_account.py` verifying that `refresh_token` is updated in SQLite after token refresh.

Fixes #41